### PR TITLE
Apply lint tools to main

### DIFF
--- a/gifs/index.html
+++ b/gifs/index.html
@@ -57,6 +57,9 @@
         <a href="kermit-head-turn.gif"><code>kermit-head-turn.gif</code></a>
       </li>
       <li>
+        <a href="okily-dokily.gif"><code>okily-dokily.gif</code></a>
+      </li>
+      <li>
         <a href="patrick-no.gif"><code>patrick-no.gif</code></a>
       </li>
       <li>

--- a/index.html
+++ b/index.html
@@ -1184,6 +1184,18 @@
         <a href="2025-02-01-33c3.jpg"><code>2025-02-01-33c3.jpg</code></a>
       </li>
       <li>
+        <a href="2025-02-03-fd7d.jpg"><code>2025-02-03-fd7d.jpg</code></a>
+      </li>
+      <li>
+        <a href="2025-02-05-9af8.jpg"><code>2025-02-05-9af8.jpg</code></a>
+      </li>
+      <li>
+        <a href="2025-02-10-0da8.jpg"><code>2025-02-10-0da8.jpg</code></a>
+      </li>
+      <li>
+        <a href="2025-02-12-3680.jpg"><code>2025-02-12-3680.jpg</code></a>
+      </li>
+      <li>
         <a href="229276025-9eda8502-324e-4c70-b870-47bef2ce4468.png">
           <code>229276025-9eda8502-324e-4c70-b870-47bef2ce4468.png</code>
         </a>
@@ -1250,6 +1262,9 @@
             <a href="gifs/kermit-head-turn.gif">
               <code>kermit-head-turn.gif</code>
             </a>
+          </li>
+          <li>
+            <a href="gifs/okily-dokily.gif"><code>okily-dokily.gif</code></a>
           </li>
           <li>
             <a href="gifs/patrick-no.gif"><code>patrick-no.gif</code></a>

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "devDependencies": {
-        "prettier": "^3.4.2"
+        "prettier": "^3.5.0"
       }
     },
     "node_modules/prettier": {
-      "version": "3.4.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.4.2.tgz",
-      "integrity": "sha512-e9MewbtFo+Fevyuxn/4rrcDAaq0IYxPGLvObpQjiZBMAzB9IGmzlnG9RZy3FFas+eBMu2vA0CszMeduow5dIuQ==",
+      "version": "3.5.0",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.5.0.tgz",
+      "integrity": "sha512-quyMrVt6svPS7CjQ9gKb3GLEX/rl3BCL2oa/QkNcXv4YNVBC9olt3s+H7ukto06q7B1Qz46PbrKLO34PR6vXcA==",
       "dev": true,
       "license": "MIT",
       "bin": {

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "devDependencies": {
-    "prettier": "^3.4.2"
+    "prettier": "^3.5.0"
   }
 }


### PR DESCRIPTION
This pull request applies Blaze Buildifier and clang-format formatting changes to the codebase at 6534db5aede029211bd73abdede711afd65053c8.